### PR TITLE
chore(JAQPOT-343): update onnx versions

### DIFF
--- a/jaqpotpy/models/tests/test_sklearn.py
+++ b/jaqpotpy/models/tests/test_sklearn.py
@@ -858,6 +858,61 @@ class TestModels(unittest.TestCase):
             onnx_predictions, onnx_expected, atol=1e-02
         ), f"Expected onnx_predictions == {onnx_expected}, got {onnx_predictions}"
 
+    def test_discrepancies_in_probabilities(self):
+        import numpy as np
+        from numpy.testing import assert_almost_equal
+        import pandas as pd
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.tree import DecisionTreeClassifier
+        from sklearn.ensemble import RandomForestClassifier
+        import skl2onnx
+        from onnxruntime import InferenceSession
+
+        # Create a small dataframe with 10 rows and 2 columns
+        np.random.seed(0)
+        data = {
+            "float_column": np.random.rand(10).astype(np.float64),
+            "int_column": np.random.randint(0, 100, size=10).astype(np.int64),
+        }
+        x_ = pd.DataFrame(data)
+        y = np.random.binomial(1, 0.5, size=10)
+
+        # Create a test dataset with 10 rows
+        test_data = {
+            "float_column": np.random.rand(10).astype(np.float64),
+            "int_column": np.random.randint(0, 100, size=10).astype(np.int64),
+        }
+        x_test_ = pd.DataFrame(test_data)
+
+        for cls in [LogisticRegression, DecisionTreeClassifier, RandomForestClassifier]:
+            with self.subTest(cls=cls):
+                # Select and train a model
+                if cls == LogisticRegression:
+                    x = x_.astype(np.float64)
+                    x_test = x_test_.astype(np.float64)
+                    decimal = 10
+                else:
+                    x = x_.astype(np.float32)
+                    x_test = x_test_.astype(np.float32)
+                    decimal = 4
+                model = cls()
+                model.fit(x, y)
+                # Take predictions and probabilities with sklearn
+                sklearn_preds = model.predict(x_test)
+                sklearn_probs = model.predict_proba(x_test)
+
+                # Convert the model to ONNX
+                onnx_model = skl2onnx.to_onnx(
+                    model, x.values, options={"zipmap": False}
+                )
+                # Take predictions and probabilities with ONNX
+                sess = InferenceSession(
+                    onnx_model.SerializeToString(), providers=["CPUExecutionProvider"]
+                )
+                onnx_prediction = sess.run(None, {"X": x_test.to_numpy()})
+                assert_almost_equal(sklearn_probs, onnx_prediction[1], decimal=decimal)
+                assert_almost_equal(sklearn_preds, onnx_prediction[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,9 @@ tqdm==4.66.4
 kennard-stone==2.2.1
 mendeleev==0.16.2
 pymatgen==2024.5.1
-skl2onnx==1.16.0
+skl2onnx==1.17.0
 onnx == 1.16.1
-onnxruntime==1.18.0
+onnxruntime==1.19.2
 httpx==0.27.0
 attrs==23.2.0
 python-keycloak==4.3.0


### PR DESCRIPTION
This pr solves the issue with the discrepancies coming from the estimated probabilities between sklearn and onnx runtimes for classifiers, like LogisticRegression.

Except from updating skl2onnx and onnxruntime to their latest varsions, also created a test that checks for any possible difference in the estimated probabilities from various sklearn classifiers