### PR TITLE
fix: take a copy from x_cols list

### DIFF
--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -76,7 +76,9 @@ class JaqpotpyDataset(BaseDataset):
                     "featurizer should be a list containing MolecularFeaturizer instances."
                 )
 
-        super().__init__(df=df, path=path, y_cols=y_cols, x_cols=x_cols, task=task)
+        super().__init__(
+            df=df, path=path, y_cols=y_cols, x_cols=copy.deepcopy(x_cols), task=task
+        )
 
         self._validate_column_overlap(self.smiles_cols, self.x_cols, self.y_cols)
         self._validate_column_names(self.smiles_cols, "smiles_cols")


### PR DESCRIPTION
If feature names include spaces, the replacement of these spaces will be transferred to the original x_cols list. This way x_cols cannot be used again to create a test dataset. This commit takes a deepcopy of x_cols, retaining the original list unchanged.