### PR TITLE
fix: Error warning when only ExcludeColumns was provided

### DIFF
--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -269,11 +269,13 @@ class JaqpotpyDataset(BaseDataset):
             ValueError: If FeatureSelector is not a valid sklearn feature selector.
             ValueError: If any features in SelectColumns are not in the dataset.
         """
-        if (FeatureSelector is None and SelectColumns is None) or (
-            FeatureSelector is not None and SelectColumns is not None
-        ):
+        if FeatureSelector is None and SelectColumns is None and ExcludeColumns is None:
             raise ValueError(
-                "Either FeatureSelector or SelectColumns must be provided, but not both."
+                "Only one from FeatureSelector, SelectColumns and ExcludeColumns must be provided."
+            )
+        elif FeatureSelector is not None and SelectColumns is not None:
+            raise ValueError(
+                "You cannot provide both FeatureSelector and SelectColumns."
             )
 
         if ExcludeColumns:


### PR DESCRIPTION
This commit fixes an error with the error handling of SelectFeatures of JaqpotpyDataset. The bug appeared when defining only ExcludeColumns (neither FeatureSelector or SelectColumns). Modified the error handling to solve this bug!