### PR TITLE
feat: Support optional arguments in predict

### DIFF
--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -357,6 +357,21 @@ class JaqpotpyDataset(BaseDataset):
         )
         return copied_instance
 
+    def df_astype(self, dtype):
+        """
+        Convert the dataset to the specified data type.
+
+        Args:
+            dtype: The data type to convert to.
+
+        Returns:
+            JaqpotpyDataset: The dataset converted to the specified data type.
+        """
+        self.df = self.df.astype(dtype)
+        self.X = self.X.astype(dtype)
+        self.y = self.y.astype(dtype)
+        return self
+
     def __get_X__(self):
         """
         Get a copy of the feature matrix X.

--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -367,6 +367,8 @@ class JaqpotpyDataset(BaseDataset):
         Returns:
             JaqpotpyDataset: The dataset converted to the specified data type.
         """
+        if columns is None:
+            columns = self.df.columns
         self.df[columns] = self.df[columns].astype(dtype)
         valid_X_columns = [col for col in columns if col in self.X.columns]
         self.X[valid_X_columns] = self.X[valid_X_columns].astype(dtype)

--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -357,7 +357,7 @@ class JaqpotpyDataset(BaseDataset):
         )
         return copied_instance
 
-    def df_astype(self, columns, dtype):
+    def df_astype(self, dtype, columns=None):
         """
         Convert the dataset to the specified data type.
 

--- a/jaqpotpy/datasets/jaqpotpy_dataset.py
+++ b/jaqpotpy/datasets/jaqpotpy_dataset.py
@@ -357,7 +357,7 @@ class JaqpotpyDataset(BaseDataset):
         )
         return copied_instance
 
-    def df_astype(self, dtype):
+    def df_astype(self, columns, dtype):
         """
         Convert the dataset to the specified data type.
 
@@ -367,9 +367,11 @@ class JaqpotpyDataset(BaseDataset):
         Returns:
             JaqpotpyDataset: The dataset converted to the specified data type.
         """
-        self.df = self.df.astype(dtype)
-        self.X = self.X.astype(dtype)
-        self.y = self.y.astype(dtype)
+        self.df[columns] = self.df[columns].astype(dtype)
+        valid_X_columns = [col for col in columns if col in self.X.columns]
+        self.X[valid_X_columns] = self.X[valid_X_columns].astype(dtype)
+        if self.y_cols in columns:
+            self.y = self.y.astype(dtype)
         return self
 
     def __get_X__(self):

--- a/jaqpotpy/models/sklearn.py
+++ b/jaqpotpy/models/sklearn.py
@@ -566,7 +566,6 @@ class SklearnModel(Model):
                 self.model.__class__.__name__ == "GaussianProcessRegressor"
                 and "return_std" in kwargs
             ):
-                # isinstance(sklearn_prediction, tuple) and len(sklearn_prediction) == 2:
                 endpoint_prediction = sklearn_prediction[0]
                 std_prediction = sklearn_prediction[1]
             else:


### PR DESCRIPTION
This commit:

- adds `df_astype()` method in JaqpotpyDataset to enable the dtype transformation of the data
- adds keyword arguments (**kwargs) in predict function (in case arguments are needed to take predictions with sklearn)
- facilitates the y scale and the inverse transformation in case of Gaussian process regressor (as the native normalize_y parameter of GPR is not compatible with onnx)