### PR TITLE
fix: install necessary only dependencies for jaqpotpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,36 +15,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "attrs==23.2.0",
-    "httpx==0.27.0",
-    "kennard-stone==2.2.1",
-    "mendeleev==0.16.2",
-    "mordredcommunity==2.0.5",
-    "onnx==1.17.0",
-    "onnxmltools==1.12.0",
-    "onnxruntime==1.19.2",
-    "pandas==2.2.2",
-    "polling2==0.5.0",
-    "pre-commit==4.0.1",
-    "pydantic==2.7.1",
-    "pydotplus==2.0.2",
-    "pyjwt==2.8.0",
-    "pymatgen==2024.5.1",
-    "python-dotenv==1.0.1",
-    "python-keycloak==4.3.0",
-    "rdkit==2023.9.6",
-    "requests==2.32.2",
-    "ruff==0.6.3",
-    "scikit-learn==1.5.0",
-    "setuptools==75.6.0",
-    "simplejson==3.19.2",
-    "skl2onnx==1.17.0",
-    "torch-geometric==2.5.0",
-    "torch==2.3.0",
-    "tqdm==4.66.4",
-    "xgboost==2.1.1",
-    "jaqpot-api-client>=6.40.7",
-    "jaqpot-python-sdk==6.0.2"
+    "torch>=2.0.0",
+    "onnx>=1.13.0",
+    "onnxruntime>=1.13.0",
+    "httpx",
+    "pydantic>=2.0",
+    "jaqpot-api-client>=6.40.7"
 ]
 
 [[project.authors]]


### PR DESCRIPTION
pyproject.toml is forcing installation of all the libraries in the requirements file + specific versions, which creates a bunch of conflicts in any environment. This shouldn't be the case. Jaqpotpy should be a lightweight library that anybody can use inside their jupyter notebook without creating conflicts. They should resolve the conflicts on their environment if any. 

Namely jaqpotpy is trying to install these things in my environment: 

```
Collecting jaqpotpy
  Downloading jaqpotpy-6.21.3-py3-none-any.whl.metadata (4.4 kB)
Collecting attrs==23.2.0 (from jaqpotpy)
  Downloading attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
Collecting httpx==0.27.0 (from jaqpotpy)
  Downloading httpx-0.27.0-py3-none-any.whl.metadata (7.2 kB)
Collecting jaqpot-api-client>=6.40.7 (from jaqpotpy)
  Downloading jaqpot_api_client-6.41.0-py3-none-any.whl.metadata (1.7 kB)
Collecting jaqpot-python-sdk==6.0.2 (from jaqpotpy)
  Downloading jaqpot_python_sdk-6.0.2-py3-none-any.whl.metadata (1.6 kB)
Collecting kennard-stone==2.2.1 (from jaqpotpy)
  Downloading kennard_stone-2.2.1-py3-none-any.whl.metadata (9.0 kB)
Collecting mendeleev==0.16.2 (from jaqpotpy)
  Downloading mendeleev-0.16.2-py3-none-any.whl.metadata (19 kB)
Collecting mordredcommunity==2.0.5 (from jaqpotpy)
  Downloading mordredcommunity-2.0.5-py3-none-any.whl.metadata (6.2 kB)
Requirement already satisfied: onnx==1.17.0 in /usr/local/lib/python3.11/dist-packages (from jaqpotpy) (1.17.0)
Collecting onnxmltools==1.12.0 (from jaqpotpy)
  Downloading onnxmltools-1.12.0-py2.py3-none-any.whl.metadata (9.4 kB)
Collecting onnxruntime==1.19.2 (from jaqpotpy)
  Downloading onnxruntime-1.19.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (4.5 kB)
Requirement already satisfied: pandas==2.2.2 in /usr/local/lib/python3.11/dist-packages (from jaqpotpy) (2.2.2)
Collecting polling2==0.5.0 (from jaqpotpy)
  Downloading polling2-0.5.0-py2.py3-none-any.whl.metadata (2.7 kB)
Collecting pre-commit==4.0.1 (from jaqpotpy)
  Downloading pre_commit-4.0.1-py2.py3-none-any.whl.metadata (1.3 kB)
Collecting pydantic==2.7.1 (from jaqpotpy)
  Downloading pydantic-2.7.1-py3-none-any.whl.metadata (107 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 107.3/107.3 kB 4.2 MB/s eta 0:00:00
Requirement already satisfied: pydotplus==2.0.2 in /usr/local/lib/python3.11/dist-packages (from jaqpotpy) (2.0.2)
Collecting pyjwt==2.8.0 (from jaqpotpy)
  Downloading PyJWT-2.8.0-py3-none-any.whl.metadata (4.2 kB)
Collecting pymatgen==2024.5.1 (from jaqpotpy)
  Downloading pymatgen-2024.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (13 kB)
Collecting python-dotenv==1.0.1 (from jaqpotpy)
  Downloading python_dotenv-1.0.1-py3-none-any.whl.metadata (23 kB)
Collecting python-keycloak==4.3.0 (from jaqpotpy)
  Downloading python_keycloak-4.3.0-py3-none-any.whl.metadata (5.9 kB)
Collecting rdkit==2023.9.6 (from jaqpotpy)
  Downloading rdkit-2023.9.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.9 kB)
Collecting requests==2.32.2 (from jaqpotpy)
  Downloading requests-2.32.2-py3-none-any.whl.metadata (4.6 kB)
Collecting ruff==0.6.3 (from jaqpotpy)
  Downloading ruff-0.6.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (25 kB)
Collecting scikit-learn==1.5.0 (from jaqpotpy)
  Downloading scikit_learn-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
Collecting setuptools==75.6.0 (from jaqpotpy)
  Downloading setuptools-75.6.0-py3-none-any.whl.metadata (6.7 kB)
Collecting simplejson==3.19.2 (from jaqpotpy)
  Downloading simplejson-3.19.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.1 kB)
Collecting skl2onnx==1.17.0 (from jaqpotpy)
  Downloading skl2onnx-1.17.0-py2.py3-none-any.whl.metadata (3.2 kB)
Collecting torch-geometric==2.5.0 (from jaqpotpy)
  Downloading torch_geometric-2.5.0-py3-none-any.whl.metadata (64 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.2/64.2 kB 6.4 MB/s eta 0:00:00
Collecting torch==2.3.0 (from jaqpotpy)
  Downloading torch-2.3.0-cp311-cp311-manylinux1_x86_64.whl.metadata (26 kB)
Collecting tqdm==4.66.4 (from jaqpotpy)
  Downloading tqdm-4.66.4-py3-none-any.whl.metadata (57 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 57.6/57.6 kB 5.5 MB/s eta 0:00:00
Collecting xgboost==2.1.1 (from jaqpotpy)
  Downloading xgboost-2.1.1-py3-none-manylinux_2_28_x86_64.whl.metadata (2.1 kB)
Requirement already satisfied: anyio in /usr/local/lib/python3.11/dist-packages (from httpx==0.27.0->jaqpotpy) (3.7.1)
Requirement already satisfied: certifi in /usr/local/lib/python3.11/dist-packages (from httpx==0.27.0->jaqpotpy) (2025.1.31)
Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.11/dist-packages (from httpx==0.27.0->jaqpotpy) (1.0.7)
Requirement already satisfied: idna in /usr/local/lib/python3.11/dist-packages (from httpx==0.27.0->jaqpotpy) (3.10)
Requirement already satisfied: sniffio in /usr/local/lib/python3.11/dist-packages (from httpx==0.27.0->jaqpotpy) (1.3.1)
Requirement already satisfied: numpy>=1.20.0 in /usr/local/lib/python3.11/dist-packages (from kennard-stone==2.2.1->jaqpotpy) (1.26.4)
Requirement already satisfied: Pygments<3.0.0,>=2.11.2 in /usr/local/lib/python3.11/dist-packages (from mendeleev==0.16.2->jaqpotpy) (2.18.0)
Requirement already satisfied: SQLAlchemy>=1.4.0 in /usr/local/lib/python3.11/dist-packages (from mendeleev==0.16.2->jaqpotpy) (2.0.38)
Collecting colorama<0.5.0,>=0.4.6 (from mendeleev==0.16.2->jaqpotpy)
  Downloading colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Collecting pyfiglet<0.9,>=0.8.post1 (from mendeleev==0.16.2->jaqpotpy)
  Downloading pyfiglet-0.8.post1-py2.py3-none-any.whl.metadata (1.3 kB)
Requirement already satisfied: six in /usr/local/lib/python3.11/dist-packages (from mordredcommunity==2.0.5->jaqpotpy) (1.17.0)
Requirement already satisfied: networkx in /usr/local/lib/python3.11/dist-packages (from mordredcommunity==2.0.5->jaqpotpy) (3.4.2)
Requirement already satisfied: packaging in /usr/local/lib/python3.11/dist-packages (from mordredcommunity==2.0.5->jaqpotpy) (24.2)
Requirement already satisfied: protobuf>=3.20.2 in /usr/local/lib/python3.11/dist-packages (from onnx==1.17.0->jaqpotpy) (4.25.6)
Requirement already satisfied: coloredlogs in /usr/local/lib/python3.11/dist-packages (from onnxruntime==1.19.2->jaqpotpy) (15.0.1)
Requirement already satisfied: flatbuffers in /usr/local/lib/python3.11/dist-packages (from onnxruntime==1.19.2->jaqpotpy) (25.2.10)
Requirement already satisfied: sympy in /usr/local/lib/python3.11/dist-packages (from onnxruntime==1.19.2->jaqpotpy) (1.13.1)
Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.11/dist-packages (from pandas==2.2.2->jaqpotpy) (2.8.2)
Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.11/dist-packages (from pandas==2.2.2->jaqpotpy) (2025.1)
Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.11/dist-packages (from pandas==2.2.2->jaqpotpy) (2025.1)
Collecting cfgv>=2.0.0 (from pre-commit==4.0.1->jaqpotpy)
  Downloading cfgv-3.4.0-py2.py3-none-any.whl.metadata (8.5 kB)
Collecting identify>=1.0.0 (from pre-commit==4.0.1->jaqpotpy)
  Downloading identify-2.6.9-py2.py3-none-any.whl.metadata (4.4 kB)
Collecting nodeenv>=0.11.1 (from pre-commit==4.0.1->jaqpotpy)
  Downloading nodeenv-1.9.1-py2.py3-none-any.whl.metadata (21 kB)
Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.11/dist-packages (from pre-commit==4.0.1->jaqpotpy) (6.0.2)
Collecting virtualenv>=20.10.0 (from pre-commit==4.0.1->jaqpotpy)
  Downloading virtualenv-20.30.0-py3-none-any.whl.metadata (4.5 kB)
Requirement already satisfied: annotated-types>=0.4.0 in /usr/local/lib/python3.11/dist-packages (from pydantic==2.7.1->jaqpotpy) (0.7.0)
Collecting pydantic-core==2.18.2 (from pydantic==2.7.1->jaqpotpy)
  Downloading pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.5 kB)
Requirement already satisfied: typing-extensions>=4.6.1 in /usr/local/lib/python3.11/dist-packages (from pydantic==2.7.1->jaqpotpy) (4.12.2)
Requirement already satisfied: pyparsing>=2.0.1 in /usr/local/lib/python3.11/dist-packages (from pydotplus==2.0.2->jaqpotpy) (3.2.1)
Requirement already satisfied: matplotlib>=1.5 in /usr/local/lib/python3.11/dist-packages (from pymatgen==2024.5.1->jaqpotpy) (3.10.0)
Collecting monty>=2024.2.2 (from pymatgen==2024.5.1->jaqpotpy)
  Downloading monty-2025.3.3-py3-none-any.whl.metadata (3.6 kB)
Collecting palettable>=3.1.1 (from pymatgen==2024.5.1->jaqpotpy)
  Downloading palettable-3.3.3-py2.py3-none-any.whl.metadata (3.3 kB)
Requirement already satisfied: plotly>=4.5.0 in /usr/local/lib/python3.11/dist-packages (from pymatgen==2024.5.1->jaqpotpy) (5.24.1)
Collecting pybtex (from pymatgen==2024.5.1->jaqpotpy)
  Downloading pybtex-0.24.0-py2.py3-none-any.whl.metadata (2.0 kB)
Collecting ruamel.yaml>=0.17.0 (from pymatgen==2024.5.1->jaqpotpy)
  Downloading ruamel.yaml-0.18.10-py3-none-any.whl.metadata (23 kB)
Requirement already satisfied: scipy>=1.5.0 in /usr/local/lib/python3.11/dist-packages (from pymatgen==2024.5.1->jaqpotpy) (1.13.1)
Collecting spglib>=2.0.2 (from pymatgen==2024.5.1->jaqpotpy)
  Downloading spglib-2.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.2 kB)
Requirement already satisfied: tabulate in /usr/local/lib/python3.11/dist-packages (from pymatgen==2024.5.1->jaqpotpy) (0.9.0)
Collecting uncertainties>=3.1.4 (from pymatgen==2024.5.1->jaqpotpy)
  Downloading uncertainties-3.2.2-py3-none-any.whl.metadata (6.9 kB)
Requirement already satisfied: joblib in /usr/local/lib/python3.11/dist-packages (from pymatgen==2024.5.1->jaqpotpy) (1.4.2)
Collecting async-property>=0.2.2 (from python-keycloak==4.3.0->jaqpotpy)
  Downloading async_property-0.2.2-py2.py3-none-any.whl.metadata (5.3 kB)
Collecting deprecation>=2.1.0 (from python-keycloak==4.3.0->jaqpotpy)
  Downloading deprecation-2.1.0-py2.py3-none-any.whl.metadata (4.6 kB)
Collecting jwcrypto>=1.5.4 (from python-keycloak==4.3.0->jaqpotpy)
  Downloading jwcrypto-1.5.6-py3-none-any.whl.metadata (3.1 kB)
Requirement already satisfied: requests-toolbelt>=0.6.0 in /usr/local/lib/python3.11/dist-packages (from python-keycloak==4.3.0->jaqpotpy) (1.0.0)
Requirement already satisfied: Pillow in /usr/local/lib/python3.11/dist-packages (from rdkit==2023.9.6->jaqpotpy) (11.1.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests==2.32.2->jaqpotpy) (3.4.1)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests==2.32.2->jaqpotpy) (2.3.0)
Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.11/dist-packages (from scikit-learn==1.5.0->jaqpotpy) (3.5.0)
Collecting onnxconverter-common>=1.7.0 (from skl2onnx==1.17.0->jaqpotpy)
  Downloading onnxconverter_common-1.14.0-py2.py3-none-any.whl.metadata (4.2 kB)
Requirement already satisfied: filelock in /usr/local/lib/python3.11/dist-packages (from torch==2.3.0->jaqpotpy) (3.17.0)
Requirement already satisfied: jinja2 in /usr/local/lib/python3.11/dist-packages (from torch==2.3.0->jaqpotpy) (3.1.5)
Requirement already satisfied: fsspec in /usr/local/lib/python3.11/dist-packages (from torch==2.3.0->jaqpotpy) (2024.10.0)
Collecting nvidia-cuda-nvrtc-cu12==12.1.105 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-cuda-runtime-cu12==12.1.105 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-cuda-cupti-cu12==12.1.105 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-cudnn-cu12==8.9.2.26 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-cublas-cu12==12.1.3.1 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-cufft-cu12==11.0.2.54 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-curand-cu12==10.3.2.106 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-cusolver-cu12==11.4.5.107 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-cusparse-cu12==12.1.0.106 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-nccl-cu12==2.20.5 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl.metadata (1.8 kB)
Collecting nvidia-nvtx-cu12==12.1.105 (from torch==2.3.0->jaqpotpy)
  Downloading nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl.metadata (1.7 kB)
Collecting triton==2.3.0 (from torch==2.3.0->jaqpotpy)
  Downloading triton-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.4 kB)
Requirement already satisfied: aiohttp in /usr/local/lib/python3.11/dist-packages (from torch-geometric==2.5.0->jaqpotpy) (3.11.13)
Requirement already satisfied: psutil>=5.8.0 in /usr/local/lib/python3.11/dist-packages (from torch-geometric==2.5.0->jaqpotpy) (5.9.5)
Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.11/dist-packages (from httpcore==1.*->httpx==0.27.0->jaqpotpy) (0.14.0)
Requirement already satisfied: nvidia-nvjitlink-cu12 in /usr/local/lib/python3.11/dist-packages (from nvidia-cusolver-cu12==11.4.5.107->torch==2.3.0->jaqpotpy) (12.4.127)
Requirement already satisfied: cryptography>=3.4 in /usr/local/lib/python3.11/dist-packages (from jwcrypto>=1.5.4->python-keycloak==4.3.0->jaqpotpy) (43.0.3)
Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=1.5->pymatgen==2024.5.1->jaqpotpy) (1.3.1)
Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=1.5->pymatgen==2024.5.1->jaqpotpy) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=1.5->pymatgen==2024.5.1->jaqpotpy) (4.56.0)
Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/lib/python3.11/dist-packages (from matplotlib>=1.5->pymatgen==2024.5.1->jaqpotpy) (1.4.8)
Collecting protobuf>=3.20.2 (from onnx==1.17.0->jaqpotpy)
  Downloading protobuf-3.20.2-py2.py3-none-any.whl.metadata (720 bytes)
Requirement already satisfied: tenacity>=6.2.0 in /usr/local/lib/python3.11/dist-packages (from plotly>=4.5.0->pymatgen==2024.5.1->jaqpotpy) (9.0.0)
Collecting ruamel.yaml.clib>=0.2.7 (from ruamel.yaml>=0.17.0->pymatgen==2024.5.1->jaqpotpy)
  Downloading ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.7 kB)
Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.11/dist-packages (from SQLAlchemy>=1.4.0->mendeleev==0.16.2->jaqpotpy) (3.1.1)
Collecting distlib<1,>=0.3.7 (from virtualenv>=20.10.0->pre-commit==4.0.1->jaqpotpy)
  Downloading distlib-0.3.9-py2.py3-none-any.whl.metadata (5.2 kB)
Requirement already satisfied: platformdirs<5,>=3.9.1 in /usr/local/lib/python3.11/dist-packages (from virtualenv>=20.10.0->pre-commit==4.0.1->jaqpotpy) (4.3.6)
Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (2.4.6)
Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (1.3.2)
Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (1.5.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (6.1.0)
Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (0.3.0)
Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.11/dist-packages (from aiohttp->torch-geometric==2.5.0->jaqpotpy) (1.18.3)
Requirement already satisfied: humanfriendly>=9.1 in /usr/local/lib/python3.11/dist-packages (from coloredlogs->onnxruntime==1.19.2->jaqpotpy) (10.0)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.11/dist-packages (from jinja2->torch==2.3.0->jaqpotpy) (3.0.2)
Collecting latexcodec>=1.0.4 (from pybtex->pymatgen==2024.5.1->jaqpotpy)
  Downloading latexcodec-3.0.0-py3-none-any.whl.metadata (4.9 kB)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.11/dist-packages (from sympy->onnxruntime==1.19.2->jaqpotpy) (1.3.0)
Requirement already satisfied: cffi>=1.12 in /usr/local/lib/python3.11/dist-packages (from cryptography>=3.4->jwcrypto>=1.5.4->python-keycloak==4.3.0->jaqpotpy) (1.17.1)
Requirement already satisfied: pycparser in /usr/local/lib/python3.11/dist-packages (from cffi>=1.12->cryptography>=3.4->jwcrypto>=1.5.4->python-keycloak==4.3.0->jaqpotpy) (2.22)
Downloading jaqpotpy-6.21.3-py3-none-any.whl (131 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 131.5/131.5 kB 10.2 MB/s eta 0:00:00
Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 5.7 MB/s eta 0:00:00
Downloading httpx-0.27.0-py3-none-any.whl (75 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 75.6/75.6 kB 7.4 MB/s eta 0:00:00
Downloading jaqpot_python_sdk-6.0.2-py3-none-any.whl (9.2 kB)
Downloading kennard_stone-2.2.1-py3-none-any.whl (14 kB)
Downloading mendeleev-0.16.2-py3-none-any.whl (353 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 353.2/353.2 kB 15.7 MB/s eta 0:00:00
Downloading mordredcommunity-2.0.5-py3-none-any.whl (175 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 176.0/176.0 kB 14.6 MB/s eta 0:00:00
Downloading onnxmltools-1.12.0-py2.py3-none-any.whl (329 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 329.0/329.0 kB 28.5 MB/s eta 0:00:00
Downloading onnxruntime-1.19.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (13.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.2/13.2 MB 98.9 MB/s eta 0:00:00
Downloading polling2-0.5.0-py2.py3-none-any.whl (6.4 kB)
Downloading pre_commit-4.0.1-py2.py3-none-any.whl (218 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 218.7/218.7 kB 19.4 MB/s eta 0:00:00
Downloading pydantic-2.7.1-py3-none-any.whl (409 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 409.3/409.3 kB 35.0 MB/s eta 0:00:00
Downloading PyJWT-2.8.0-py3-none-any.whl (22 kB)
Downloading pymatgen-2024.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.9/4.9 MB 99.3 MB/s eta 0:00:00
Downloading python_dotenv-1.0.1-py3-none-any.whl (19 kB)
Downloading python_keycloak-4.3.0-py3-none-any.whl (76 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76.0/76.0 kB 7.3 MB/s eta 0:00:00
Downloading rdkit-2023.9.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (34.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 34.9/34.9 MB 30.4 MB/s eta 0:00:00
Downloading requests-2.32.2-py3-none-any.whl (63 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 63.9/63.9 kB 5.6 MB/s eta 0:00:00
Downloading ruff-0.6.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (10.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.3/10.3 MB 126.9 MB/s eta 0:00:00
Downloading scikit_learn-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.3/13.3 MB 98.2 MB/s eta 0:00:00
Downloading setuptools-75.6.0-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 65.3 MB/s eta 0:00:00
Downloading simplejson-3.19.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (144 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 144.7/144.7 kB 14.3 MB/s eta 0:00:00
Downloading skl2onnx-1.17.0-py2.py3-none-any.whl (298 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.4/298.4 kB 24.7 MB/s eta 0:00:00
Downloading torch-2.3.0-cp311-cp311-manylinux1_x86_64.whl (779.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 779.2/779.2 MB 2.1 MB/s eta 0:00:00
Downloading torch_geometric-2.5.0-py3-none-any.whl (1.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 59.4 MB/s eta 0:00:00
Downloading tqdm-4.66.4-py3-none-any.whl (78 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.3/78.3 kB 8.0 MB/s eta 0:00:00
Downloading xgboost-2.1.1-py3-none-manylinux_2_28_x86_64.whl (153.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 153.9/153.9 MB 7.1 MB/s eta 0:00:00
Downloading nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl (410.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 410.6/410.6 MB 3.6 MB/s eta 0:00:00
Downloading nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (14.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 14.1/14.1 MB 68.7 MB/s eta 0:00:00
Downloading nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (23.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 23.7/23.7 MB 57.0 MB/s eta 0:00:00
Downloading nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (823 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 823.6/823.6 kB 55.1 MB/s eta 0:00:00
Downloading nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl (731.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 731.7/731.7 MB 692.6 kB/s eta 0:00:00
Downloading nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl (121.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.6/121.6 MB 7.8 MB/s eta 0:00:00
Downloading nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl (56.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 56.5/56.5 MB 11.9 MB/s eta 0:00:00
Downloading nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl (124.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 124.2/124.2 MB 8.8 MB/s eta 0:00:00
Downloading nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl (196.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 196.0/196.0 MB 6.5 MB/s eta 0:00:00
Downloading nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl (176.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 176.2/176.2 MB 8.1 MB/s eta 0:00:00
Downloading nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (99 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 99.1/99.1 kB 9.4 MB/s eta 0:00:00
Downloading pydantic_core-2.18.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 83.5 MB/s eta 0:00:00
Downloading triton-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (168.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 168.1/168.1 MB 6.7 MB/s eta 0:00:00
Downloading jaqpot_api_client-6.41.0-py3-none-any.whl (134 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.6/134.6 kB 11.9 MB/s eta 0:00:00
Downloading async_property-0.2.2-py2.py3-none-any.whl (9.5 kB)
Downloading cfgv-3.4.0-py2.py3-none-any.whl (7.2 kB)
Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Downloading deprecation-2.1.0-py2.py3-none-any.whl (11 kB)
Downloading identify-2.6.9-py2.py3-none-any.whl (99 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 99.1/99.1 kB 9.7 MB/s eta 0:00:00
Downloading jwcrypto-1.5.6-py3-none-any.whl (92 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 92.5/92.5 kB 7.9 MB/s eta 0:00:00
Downloading monty-2025.3.3-py3-none-any.whl (51 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 51.9/51.9 kB 5.2 MB/s eta 0:00:00
Downloading nodeenv-1.9.1-py2.py3-none-any.whl (22 kB)
Downloading onnxconverter_common-1.14.0-py2.py3-none-any.whl (84 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 84.5/84.5 kB 8.6 MB/s eta 0:00:00
Downloading protobuf-3.20.2-py2.py3-none-any.whl (162 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 162.1/162.1 kB 15.3 MB/s eta 0:00:00
Downloading palettable-3.3.3-py2.py3-none-any.whl (332 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 332.3/332.3 kB 27.7 MB/s eta 0:00:00
Downloading pyfiglet-0.8.post1-py2.py3-none-any.whl (865 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 865.8/865.8 kB 54.2 MB/s eta 0:00:00
Downloading ruamel.yaml-0.18.10-py3-none-any.whl (117 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 117.7/117.7 kB 10.8 MB/s eta 0:00:00
Downloading spglib-2.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (809 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 809.0/809.0 kB 49.3 MB/s eta 0:00:00
Downloading uncertainties-3.2.2-py3-none-any.whl (58 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.3/58.3 kB 5.1 MB/s eta 0:00:00
Downloading virtualenv-20.30.0-py3-none-any.whl (4.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 105.5 MB/s eta 0:00:00
Downloading pybtex-0.24.0-py2.py3-none-any.whl (561 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 561.4/561.4 kB 37.0 MB/s eta 0:00:00
Downloading distlib-0.3.9-py2.py3-none-any.whl (468 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 469.0/469.0 kB 34.2 MB/s eta 0:00:00
Downloading latexcodec-3.0.0-py3-none-any.whl (18 kB)
Downloading ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (739 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 739.1/739.1 kB 46.6 MB/s eta 0:00:00
Installing collected packages: pyfiglet, polling2, distlib, async-property, virtualenv, uncertainties, triton, tqdm, spglib, simplejson, setuptools, ruff, ruamel.yaml.clib, requests, rdkit, python-dotenv, pyjwt, pydantic-core, protobuf, palettable, nvidia-nvtx-cu12, nvidia-nccl-cu12, nvidia-cusparse-cu12, nvidia-curand-cu12, nvidia-cufft-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, nodeenv, latexcodec, jaqpot-api-client, identify, deprecation, colorama, cfgv, attrs, xgboost, scikit-learn, ruamel.yaml, pydantic, pybtex, pre-commit, onnxruntime, nvidia-cusolver-cu12, nvidia-cudnn-cu12, mordredcommunity, jaqpot-python-sdk, httpx, torch-geometric, torch, onnxmltools, onnxconverter-common, monty, mendeleev, kennard-stone, jwcrypto, skl2onnx, python-keycloak, pymatgen, jaqpotpy
  Attempting uninstall: triton
    Found existing installation: triton 3.1.0
    Uninstalling triton-3.1.0:
      Successfully uninstalled triton-3.1.0
  Attempting uninstall: tqdm
    Found existing installation: tqdm 4.67.1
    Uninstalling tqdm-4.67.1:
      Successfully uninstalled tqdm-4.67.1
  Attempting uninstall: setuptools
    Found existing installation: setuptools 75.1.0
    Uninstalling setuptools-75.1.0:
      Successfully uninstalled setuptools-75.1.0
  Attempting uninstall: requests
    Found existing installation: requests 2.32.3
    Uninstalling requests-2.32.3:
      Successfully uninstalled requests-2.32.3
  Attempting uninstall: pyjwt
    Found existing installation: PyJWT 2.10.1
    Uninstalling PyJWT-2.10.1:
      Successfully uninstalled PyJWT-2.10.1
  Attempting uninstall: pydantic-core
    Found existing installation: pydantic_core 2.27.2
    Uninstalling pydantic_core-2.27.2:
      Successfully uninstalled pydantic_core-2.27.2
  Attempting uninstall: protobuf
    Found existing installation: protobuf 4.25.6
    Uninstalling protobuf-4.25.6:
      Successfully uninstalled protobuf-4.25.6
  Attempting uninstall: nvidia-nvtx-cu12
    Found existing installation: nvidia-nvtx-cu12 12.4.127
    Uninstalling nvidia-nvtx-cu12-12.4.127:
      Successfully uninstalled nvidia-nvtx-cu12-12.4.127
  Attempting uninstall: nvidia-nccl-cu12
    Found existing installation: nvidia-nccl-cu12 2.21.5
    Uninstalling nvidia-nccl-cu12-2.21.5:
      Successfully uninstalled nvidia-nccl-cu12-2.21.5
  Attempting uninstall: nvidia-cusparse-cu12
    Found existing installation: nvidia-cusparse-cu12 12.3.1.170
    Uninstalling nvidia-cusparse-cu12-12.3.1.170:
      Successfully uninstalled nvidia-cusparse-cu12-12.3.1.170
  Attempting uninstall: nvidia-curand-cu12
    Found existing installation: nvidia-curand-cu12 10.3.5.147
    Uninstalling nvidia-curand-cu12-10.3.5.147:
      Successfully uninstalled nvidia-curand-cu12-10.3.5.147
  Attempting uninstall: nvidia-cufft-cu12
    Found existing installation: nvidia-cufft-cu12 11.2.1.3
    Uninstalling nvidia-cufft-cu12-11.2.1.3:
      Successfully uninstalled nvidia-cufft-cu12-11.2.1.3
  Attempting uninstall: nvidia-cuda-runtime-cu12
    Found existing installation: nvidia-cuda-runtime-cu12 12.4.127
    Uninstalling nvidia-cuda-runtime-cu12-12.4.127:
      Successfully uninstalled nvidia-cuda-runtime-cu12-12.4.127
  Attempting uninstall: nvidia-cuda-nvrtc-cu12
    Found existing installation: nvidia-cuda-nvrtc-cu12 12.4.127
    Uninstalling nvidia-cuda-nvrtc-cu12-12.4.127:
      Successfully uninstalled nvidia-cuda-nvrtc-cu12-12.4.127
  Attempting uninstall: nvidia-cuda-cupti-cu12
    Found existing installation: nvidia-cuda-cupti-cu12 12.4.127
    Uninstalling nvidia-cuda-cupti-cu12-12.4.127:
      Successfully uninstalled nvidia-cuda-cupti-cu12-12.4.127
  Attempting uninstall: nvidia-cublas-cu12
    Found existing installation: nvidia-cublas-cu12 12.4.5.8
    Uninstalling nvidia-cublas-cu12-12.4.5.8:
      Successfully uninstalled nvidia-cublas-cu12-12.4.5.8
  Attempting uninstall: attrs
    Found existing installation: attrs 25.1.0
    Uninstalling attrs-25.1.0:
      Successfully uninstalled attrs-25.1.0
  Attempting uninstall: xgboost
    Found existing installation: xgboost 2.1.4
    Uninstalling xgboost-2.1.4:
      Successfully uninstalled xgboost-2.1.4
  Attempting uninstall: scikit-learn
    Found existing installation: scikit-learn 1.6.1
    Uninstalling scikit-learn-1.6.1:
      Successfully uninstalled scikit-learn-1.6.1
  Attempting uninstall: pydantic
    Found existing installation: pydantic 2.10.6
    Uninstalling pydantic-2.10.6:
      Successfully uninstalled pydantic-2.10.6
  Attempting uninstall: onnxruntime
    Found existing installation: onnxruntime 1.21.0
    Uninstalling onnxruntime-1.21.0:
      Successfully uninstalled onnxruntime-1.21.0
  Attempting uninstall: nvidia-cusolver-cu12
    Found existing installation: nvidia-cusolver-cu12 11.6.1.9
    Uninstalling nvidia-cusolver-cu12-11.6.1.9:
      Successfully uninstalled nvidia-cusolver-cu12-11.6.1.9
  Attempting uninstall: nvidia-cudnn-cu12
    Found existing installation: nvidia-cudnn-cu12 9.1.0.70
    Uninstalling nvidia-cudnn-cu12-9.1.0.70:
      Successfully uninstalled nvidia-cudnn-cu12-9.1.0.70
  Attempting uninstall: httpx
    Found existing installation: httpx 0.28.1
    Uninstalling httpx-0.28.1:
      Successfully uninstalled httpx-0.28.1
  Attempting uninstall: torch
    Found existing installation: torch 2.5.1+cu124
    Uninstalling torch-2.5.1+cu124:
      Successfully uninstalled torch-2.5.1+cu124
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
ipython 7.34.0 requires jedi>=0.16, which is not installed.
google-colab 1.0.0 requires requests==2.32.3, but you have requests 2.32.2 which is incompatible.
langchain 0.3.19 requires pydantic<3.0.0,>=2.7.4, but you have pydantic 2.7.1 which is incompatible.
tensorflow 2.18.0 requires protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<6.0.0dev,>=3.20.3, but you have protobuf 3.20.2 which is incompatible.
torchaudio 2.5.1+cu124 requires torch==2.5.1, but you have torch 2.3.0 which is incompatible.
tensorflow-metadata 1.16.1 requires protobuf<6.0.0dev,>=4.25.2; python_version >= "3.11", but you have protobuf 3.20.2 which is incompatible.
albumentations 2.0.5 requires pydantic>=2.9.2, but you have pydantic 2.7.1 which is incompatible.
torchvision 0.20.1+cu124 requires torch==2.5.1, but you have torch 2.3.0 which is incompatible.
grpcio-status 1.62.3 requires protobuf>=4.21.6, but you have protobuf 3.20.2 which is incompatible.
Successfully installed async-property-0.2.2 attrs-23.2.0 cfgv-3.4.0 colorama-0.4.6 deprecation-2.1.0 distlib-0.3.9 httpx-0.27.0 identify-2.6.9 jaqpot-api-client-6.41.0 jaqpot-python-sdk-6.0.2 jaqpotpy-6.21.3 jwcrypto-1.5.6 kennard-stone-2.2.1 latexcodec-3.0.0 mendeleev-0.16.2 monty-2025.3.3 mordredcommunity-2.0.5 nodeenv-1.9.1 nvidia-cublas-cu12-12.1.3.1 nvidia-cuda-cupti-cu12-12.1.105 nvidia-cuda-nvrtc-cu12-12.1.105 nvidia-cuda-runtime-cu12-12.1.105 nvidia-cudnn-cu12-8.9.2.26 nvidia-cufft-cu12-11.0.2.54 nvidia-curand-cu12-10.3.2.106 nvidia-cusolver-cu12-11.4.5.107 nvidia-cusparse-cu12-12.1.0.106 nvidia-nccl-cu12-2.20.5 nvidia-nvtx-cu12-12.1.105 onnxconverter-common-1.14.0 onnxmltools-1.12.0 onnxruntime-1.19.2 palettable-3.3.3 polling2-0.5.0 pre-commit-4.0.1 protobuf-3.20.2 pybtex-0.24.0 pydantic-2.7.1 pydantic-core-2.18.2 pyfiglet-0.8.post1 pyjwt-2.8.0 pymatgen-2024.5.1 python-dotenv-1.0.1 python-keycloak-4.3.0 rdkit-2023.9.6 requests-2.32.2 ruamel.yaml-0.18.10 ruamel.yaml.clib-0.2.12 ruff-0.6.3 scikit-learn-1.5.0 setuptools-75.6.0 simplejson-3.19.2 skl2onnx-1.17.0 spglib-2.6.0 torch-2.3.0 torch-geometric-2.5.0 tqdm-4.66.4 triton-2.3.0 uncertainties-3.2.2 virtualenv-20.30.0 xgboost-2.1.1
WARNING: The following packages were previously imported in this runtime:
  [_distutils_hack,google,setuptools,torch,torchgen,tqdm,triton]
You must restart the runtime in order to use newly installed versions.
```

